### PR TITLE
Fix snapshot URI retrieval

### DIFF
--- a/Device/onvif_ptz_controller.py
+++ b/Device/onvif_ptz_controller.py
@@ -182,6 +182,9 @@ class OnvifPTZController(QObject):  # 必须继承QObject
             self.error_signal.emit("未选择媒体profile")
 
         try:
-            return self._media_service.GetSnapshotUri({'ProfileToken': self._current_profile.token})
+            snapshot = self._media_service.GetSnapshotUri({
+                'ProfileToken': self._current_profile
+            })
+            return snapshot['Uri'] if isinstance(snapshot, dict) else snapshot.Uri
         except Exception as e:
             self.error_signal.emit(f"获取快照URI失败: {str(e)}")


### PR DESCRIPTION
## Summary
- update snapshot URI call to use stored token
- return URI string from the media service response

## Testing
- `python -m py_compile Device/onvif_ptz_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_685ac70e51a08325aae741c677abda74